### PR TITLE
Add basic test for Navigation component

### DIFF
--- a/src/components/Navigation/Navigation.test.js
+++ b/src/components/Navigation/Navigation.test.js
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import { Axios } from '../../services/api.service';
+import { fireEvent, render, screen, wait, waitForElementToBeRemoved } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import mockAPI from '../../services/test.service';
+import Navigation from './navigation.component';
+
+jest.mock('../../services/api.service');
+
+beforeEach(() => {
+  Axios.get.mockResolvedValueOnce(mockAPI.userTeams)
+  render(
+    <Router>
+      <Navigation 
+        sidebar={true}
+        setSidebar={() => {}}
+        onLoggedInChange={() => {}}
+        userInfo={mockAPI.userInfo}
+        userTeams={mockAPI.userTeams.data}
+      />
+    </Router>
+  )
+});
+
+test('Navigation component renders teams correctly', () => {
+  expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  expect(screen.getByText('CS 150')).toBeInTheDocument();
+})

--- a/src/components/Navigation/navigation.component.js
+++ b/src/components/Navigation/navigation.component.js
@@ -11,8 +11,6 @@ import {
 } from '../../services/api.service';
 import './navigation.css';
 
-// TO DO:
-// Render the most recent teams only? i.e. the last six a user interacted with
 
 function Navigation(props) {
   const showSidebar = () => props.setSidebar(!sidebar);


### PR DESCRIPTION
Add basic test for nav component
Was able to get 85% coverage with a simple render since it only loads the user's teams